### PR TITLE
Make top-level package go-gettable

### DIFF
--- a/sonde.go
+++ b/sonde.go
@@ -1,0 +1,1 @@
+package sonde


### PR DESCRIPTION
This commit adds a Golang source file to the top level of this repository, to prevent the following `go get` failure:

```
$ go get -v github.com/cloudfoundry/sonde-go
github.com/cloudfoundry/sonde-go (download)
package github.com/cloudfoundry/sonde-go: no buildable Go source files in /Users/pivotal/go/src/github.com/cloudfoundry/sonde-go
```